### PR TITLE
Fixed minor bug in manifold generation

### DIFF
--- a/Physics2D/Physics2D/PhysicsEngine/Collision.cs
+++ b/Physics2D/Physics2D/PhysicsEngine/Collision.cs
@@ -164,14 +164,14 @@ namespace Physics2D.PhysicsEngine
 				return false;
 			d = (float)Math.Sqrt (d);
 			if (inside) {
-				m.Normal = -PhysicsMath.GetNormal(a.Position, b.Position);
-				m.PenetrationDepth = r + d;
+				m.Normal = -m.normal;
+				m.PenetrationDepth = r - d;
 				m.AreColliding = true;
 				return true;
 			} 
 			else {
 				m.Normal = PhysicsMath.GetNormal(a.Position, b.Position);
-				m.PenetrationDepth = r + d;
+				m.PenetrationDepth = r - d;
 				m.AreColliding = true;
 				return true;
 			}


### PR DESCRIPTION
The PenetrationDepth should be r-d not r+d and when the body is inside another then the normal should be (closest - n) in the case of AABBvsCircle. There were typos in the tutorial.